### PR TITLE
Allow lambdas on Configuration

### DIFF
--- a/lib/ios-cert-enrollment/configuration.rb
+++ b/lib/ios-cert-enrollment/configuration.rb
@@ -18,11 +18,27 @@ module IOSCertEnrollment::Configuration
   attr_accessor *VALID_OPTIONS_KEYS
 
   def ssl_key
-    @ssl_key ||= File.read ssl_key_path
+    if @ssl_key.is_a? Proc
+      @ssl_key.call
+    else
+      @ssl_key ||= File.read ssl_key_path
+    end
   end
 
   def ssl_certificate
-    @ssl_certificate ||= File.read ssl_certificate_path
+    if @ssl_certificate.is_a? Proc
+      @ssl_certificate.call
+    else
+      @ssl_certificate ||= File.read ssl_certificate_path
+    end
+  end
+
+  def base_url
+    if @base_url.is_a? Proc
+      @base_url.call
+    else
+      @base_url
+    end
   end
 
   # Convenience method to allow configuration options to be set in a block

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -15,6 +15,12 @@ describe IOSCertEnrollment::Configuration do
       IOSCertEnrollment.ssl_key_path = 'qwer_file'
       expect(IOSCertEnrollment.ssl_key).to eq 'qwer'
     end
+    it "Can read from a lambda" do
+      IOSCertEnrollment.ssl_key = lambda { SecureRandom.base64 }
+      key1 = IOSCertEnrollment.ssl_key
+      key2 = IOSCertEnrollment.ssl_key
+      expect(key1).to_not eq key2
+    end
   end
 
   describe "#ssl_certificate" do
@@ -30,6 +36,28 @@ describe IOSCertEnrollment::Configuration do
       allow(File).to receive(:read).and_return('qwer')
       IOSCertEnrollment.ssl_certificate_path = 'qwer_file'
       expect(IOSCertEnrollment.ssl_certificate).to eq 'qwer'
+    end
+    it "Can read from a lambda" do
+      IOSCertEnrollment.ssl_certificate = lambda { SecureRandom.base64 }
+      cert1 = IOSCertEnrollment.ssl_certificate
+      cert2 = IOSCertEnrollment.ssl_certificate
+      expect(cert1).to_not eq cert2
+    end
+  end
+
+  describe "#base_url" do
+    before :each do
+      IOSCertEnrollment.base_url = nil
+    end
+    it "Can read from a variable" do
+      IOSCertEnrollment.base_url = 'asdf'
+      expect(IOSCertEnrollment.base_url).to eq 'asdf'
+    end
+    it "Can read from a lambda" do
+      IOSCertEnrollment.base_url = lambda { SecureRandom.base64 }
+      cert1 = IOSCertEnrollment.base_url
+      cert2 = IOSCertEnrollment.base_url
+      expect(cert1).to_not eq cert2
     end
   end
 


### PR DESCRIPTION
This allows lambdas to be passed in for
- ssl_key
- ssl_certificate
- base_url
